### PR TITLE
Fixed an issue with detaching the shaders

### DIFF
--- a/ParticleSystem.vcxproj
+++ b/ParticleSystem.vcxproj
@@ -31,6 +31,7 @@
     <ClCompile Include="src\cpu_particle_module.cc" />
     <ClCompile Include="src\rain_emitter.cc" />
     <ClCompile Include="src\random_fountain_emitter.cc" />
+    <ClCompile Include="src\scene.cc" />
     <ClCompile Include="src\shader.cc" />
     <ClCompile Include="src\spherical_stream_emitter.cc" />
     <ClCompile Include="src\core_opengl_renderer.cc" />
@@ -54,6 +55,7 @@
     <ClInclude Include="src\rain_emitter.hh" />
     <ClInclude Include="src\random_fountain_emitter.hh" />
     <ClInclude Include="src\renderer.hh" />
+    <ClInclude Include="src\scene.hh" />
     <ClInclude Include="src\shader.hh" />
     <ClInclude Include="src\emitter.hh" />
     <ClInclude Include="src\particle_pool.hh" />
@@ -62,6 +64,7 @@
     <ClInclude Include="src\timer.hh" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="shaders\debug_axes.vert" />
     <None Include="shaders\default.comp" />
     <None Include="shaders\default.frag" />
     <None Include="shaders\default.geom" />

--- a/ParticleSystem.vcxproj.filters
+++ b/ParticleSystem.vcxproj.filters
@@ -58,6 +58,7 @@
     <ClCompile Include="src\core_opengl_renderer.cc">
       <Filter>Renderers</Filter>
     </ClCompile>
+    <ClCompile Include="src\scene.cc" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\dynamic.hh">
@@ -122,6 +123,7 @@
     <ClInclude Include="src\core_opengl_renderer.hh">
       <Filter>Renderers</Filter>
     </ClInclude>
+    <ClInclude Include="src\scene.hh" />
   </ItemGroup>
   <ItemGroup>
     <None Include="shaders\default.comp">
@@ -140,6 +142,9 @@
       <Filter>Resource files\Shaders</Filter>
     </None>
     <None Include="shaders\default.vert">
+      <Filter>Resource files\Shaders</Filter>
+    </None>
+    <None Include="shaders\debug_axes.vert">
       <Filter>Resource files\Shaders</Filter>
     </None>
   </ItemGroup>

--- a/shaders/debug_axes.vert
+++ b/shaders/debug_axes.vert
@@ -1,0 +1,27 @@
+//A vertex shader dedicated to coloring 
+//debug axes and testing the infrastructure
+//for supporting multiple shaders
+
+#version 430
+
+layout (std140, binding = 0) uniform GlobalMatrices {
+  mat4 MVP; 
+};
+
+layout(location = 0) in vec3 vertexPosition_modelspace;
+
+out vec4 ex_Color;
+
+void main(void) {
+  vec4 vertex = vec4(vertexPosition_modelspace,1.0);
+  gl_Position = MVP*vertex;
+
+  if (vertex.x >= 0.05)
+    ex_Color = vec4(1.0,0.0,0.0,0.0);
+  else if (vertex.y >= 0.05)
+    ex_Color = vec4(0.0,1.0,0.0,0.0);
+  else if (vertex.z >= 0.05)
+    ex_Color = vec4(0.0,0.0,1.0,0.0);
+  else
+    ex_Color = vec4(1.0,1.0,1.0,0.0);    
+}

--- a/src/app.cc
+++ b/src/app.cc
@@ -25,6 +25,7 @@
 #include "event_handler.hh"
 #include "cpu_particle_module.hh"
 #include "particle_system_interface.hh"
+#include "scene.hh"
 
 // TODO: Temporary includes since test suite
 // or factory/builder are not built yet...
@@ -41,6 +42,7 @@ namespace {
 // window management system or 3D API (GLFW/Windows
 // & OpenGL/Direct3D)
 std::shared_ptr<GraphicContext> graphic_context;
+std::shared_ptr<Scene>          scene;
 }
 
 void Init() {
@@ -65,6 +67,10 @@ void Init() {
   // Event handler initialization
   event_handler::Init(graphic_context);
 
+  // Scene initialization
+  scene = std::make_shared<Scene>();
+  scene->SetDebugOption(true);
+
   // Particle system initialization
   cpu_particle_module::Init();
   std::unique_ptr<ParticleSystem<CoreGLRenderer> > wParticleSystem =
@@ -74,43 +80,14 @@ void Init() {
   cpu_particle_module::AddSystem(std::move(wParticleSystem));
 }
 
-// TODO: Add that as debugging option in one of the renderers maybe?
-// Definitely not in the renderers, since it would be duplicated
-// in every renderers
-float points[] = {
-  0.0f,0.0f,0.0f,
-  1.0f,0.0f,0.0f,
-  0.0f,0.0f,0.0f,
-  0.0f,1.0f,0.0f,
-  0.0f,0.0f,0.0f,
-  0.0f,0.0f,1.0f
-};
-
 void Run() {
-  GLuint vao = 0;
-  glGenVertexArrays(1, &vao);
-  glBindVertexArray(vao);
-  glEnableVertexAttribArray(0);
-
-  GLuint vbo = 0;
-  glGenBuffers(1, &vbo);
-  glBindBuffer(GL_ARRAY_BUFFER, vbo);
-  glBufferData(GL_ARRAY_BUFFER, 18 * sizeof(float), points, GL_STATIC_DRAW);
-  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, NULL);
-
-
   while (!graphic_context->PollWindowClosedEvent()) {
-    glBindVertexArray(vao);
-    glDrawArrays(GL_LINES, 0, 2);
-    glDrawArrays(GL_LINES, 2, 2);
-    glDrawArrays(GL_LINES, 4, 2);
-    glBindVertexArray(0);
     std::cout << "FPS: " << timer::chrono::GetFPS() << std::endl;
-    //TODO: See how UI with anttweakbar goes, but
-    //events subscription should go here if there's any
     double dt = timer::chrono::GetTimeElapsedInSeconds();
-
+    
+    scene->Render();
     cpu_particle_module::Update(dt);    
+    
     graphic_context->Update();
     timer::chrono::Update();
   }

--- a/src/core_opengl_renderer.cc
+++ b/src/core_opengl_renderer.cc
@@ -22,8 +22,8 @@
 namespace gem {
 namespace particle {
 CoreGLRenderer::CoreGLRenderer(const std::shared_ptr<ParticlePool<CoreParticles> > & a_pPool) {
-  shader_manager::AddShader("shaders/default.vert", GL_VERTEX_SHADER);
-  shader_manager::AddShader("shaders/default.frag", GL_FRAGMENT_SHADER);
+  shader_manager::CompileShaderFile("shaders/default.vert", GL_VERTEX_SHADER);
+  shader_manager::CompileShaderFile("shaders/default.frag", GL_FRAGMENT_SHADER);
   m_shaderProgram = shader_manager::CreateProgram();
 
   // VAO initialization

--- a/src/scene.cc
+++ b/src/scene.cc
@@ -1,0 +1,70 @@
+/*************************************************************************
+ * Copyright (c) 2016 Fran�ois Trudel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+*************************************************************************/
+#include "scene.hh"
+
+#include <iostream>
+
+#include "shader.hh"
+
+namespace gem {
+namespace particle {
+const GLfloat Scene::AXES_POINTS[] = {
+  0.0f,0.0f,0.0f,
+  1.0f,0.0f,0.0f,
+  0.0f,0.0f,0.0f,
+  0.0f,1.0f,0.0f,
+  0.0f,0.0f,0.0f,
+  0.0f,0.0f,1.0f
+};
+
+Scene::Scene(bool a_isDebug)
+  : m_bIsDebug(a_isDebug) {
+  shader_manager::CompileShaderFile("shaders/debug_axes.vert", GL_VERTEX_SHADER);
+  shader_manager::CompileShaderFile("shaders/default.frag", GL_FRAGMENT_SHADER);
+  m_unProgramID = shader_manager::CreateProgram();
+
+  glGenVertexArrays(1, &m_vertexArrayID);
+  glBindVertexArray(m_vertexArrayID);
+  glEnableVertexAttribArray(0);
+
+  glGenBuffers(1, &m_vertexBufferID);
+  glBindBuffer(GL_ARRAY_BUFFER, m_vertexBufferID);
+  glBufferData(GL_ARRAY_BUFFER, 18 * sizeof(GLfloat), AXES_POINTS, GL_STATIC_DRAW);
+  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, nullptr);
+}
+
+Scene::~Scene() {
+  if (m_vertexBufferID != 0) {
+    std::cout << "Scene::~Scene -> Deallocating vertex VBO" << std::endl;
+    glDeleteBuffers(1, &m_vertexBufferID);
+    m_vertexBufferID = 0;
+  }
+}
+
+void Scene::Render() {
+  if (m_bIsDebug) {
+    DrawAxes();
+  }
+}
+
+void Scene::DrawAxes() {
+  shader_manager::Use(m_unProgramID);
+  glBindVertexArray(m_vertexArrayID);
+  glDrawArrays(GL_LINES, 0, 2);
+  glDrawArrays(GL_LINES, 2, 2);
+  glDrawArrays(GL_LINES, 4, 2);
+  glBindVertexArray(0);
+}
+} /* namespace particle */
+} /* namespace gem */

--- a/src/scene.hh
+++ b/src/scene.hh
@@ -1,0 +1,52 @@
+/*************************************************************************
+ * Copyright (c) 2016 Fran�ois Trudel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+*************************************************************************/
+#ifndef SCENE_HH
+#define SCENE_HH
+
+// TODO: Should this be a singleton/namespace?
+// Since there can be only one instance of a scene
+// throughout the app...
+
+// TODO: Add lights by registering their positions
+// as an UBO in the shaders maybe?
+
+#include <GL/glew.h>
+
+namespace gem {
+namespace particle {
+class Scene{
+private:
+  static const GLfloat AXES_POINTS[];
+public:
+  Scene(bool a_isDebug = false);
+  ~Scene();
+
+  inline void SetDebugOption(bool a_isDebug) {
+    m_bIsDebug = a_isDebug;
+  }
+
+  void Render();
+private:
+  void DrawAxes();
+
+  bool    m_bIsDebug;
+  GLuint  m_vertexArrayID;
+  GLuint  m_vertexBufferID;
+  GLuint  m_unProgramID;
+}; /* class Scene*/
+} /* namespace particle */
+} /* namespace gem */
+
+#endif /* end of include guard: SCENE_HH */
+

--- a/src/shader.hh
+++ b/src/shader.hh
@@ -23,7 +23,6 @@ namespace shader_manager {
 void Init();
 void Terminate();
 
-bool AddShader(std::string a_sFileName, GLenum a_eShaderType);
 bool CompileShaderFile(std::string a_sFileName, GLenum a_eShaderType);
 bool CompileShaderText(const std::string& a_rShaderText, 
   GLenum a_eShaderType, 


### PR DESCRIPTION
shaders objects attached to a program are useless and can be safely detached. No need to check if corresponding shader id has already been compiled. glCreateShader will return 1 for each first shader created for a new program and it doesn't matter, it works this way... So removed some useless containers in the shadermanager and kept it simple. But added a compiled sources container to check if a program is the same as the one being compiled, to avoid switching programs unecessarily. Also added a scene with a debugging option for the axes to demonstrate the functionality.